### PR TITLE
Constants update to our pcb values

### DIFF
--- a/src/foreground_mercator.c
+++ b/src/foreground_mercator.c
@@ -23,7 +23,7 @@
 
 #define FRAME_SIZE 1024
 #define PHI (300.0/76800.0)	/*Lowest emited frequency deviced by the sampling frequency*/
-#define VREF 3.3
+#define VREF 2.5
 
 volatile sig_atomic_t done = 0;
 

--- a/src/mercator.c
+++ b/src/mercator.c
@@ -23,7 +23,7 @@
 
 #define FRAME_SIZE 1024
 #define PHI (300.0/76800.0)	/*Lowest emited frequency deviced by the sampling frequency*/
-#define VREF 3.3
+#define VREF 2.5
 
 volatile sig_atomic_t done = 0;
 


### PR DESCRIPTION
Changed the macro values of VREF from 3.3 to 2.5
This due to a change in the design of the electronic circuit. It is now fit to work with the pcb we designed and printed at groep t
